### PR TITLE
增加docker部署方式

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18.18.2
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install -g cnpm --registry=https://registry.npm.taobao.org && cnpm install
+
+EXPOSE 8000
+
+CMD ["npm", "start"]


### PR DESCRIPTION
提供Dockerfile可以一键部署pity前端并后台运行。
使用步骤：
1.git clone项目
2.进入项目后修改src/constants/config.ts中的域名为自己的
3.docker build -t pity-web:1.0 .构建镜像
4.启动容器：docker run -d --name=pity-web -p 8000:8000 pity-web:1.0